### PR TITLE
AVIARY-3219_AVIARY-3217_Aviary-3238_OHMS_Thesaurus

### DIFF
--- a/app/assets/javascripts/interview_manager.js
+++ b/app/assets/javascripts/interview_manager.js
@@ -21,6 +21,24 @@ function InterviewManager() {
     that.interview_transcript_id = 0;
     this.initialize = function () {
         bindEvents();
+        if($('.tokenfield').length > 0){
+            $('.tokenfield_keywords').tokenfield({
+                delimiter: ';',
+                autocomplete: {
+                source: $(".tokenfield_keywords").data().items,
+                delay: 100
+                },
+                showAutocompleteOnFocus: false
+            });
+            $('.tokenfield_subjects').tokenfield({
+                delimiter: ';',
+                autocomplete: {
+                source: $('.tokenfield_subjects').data().items,
+                delay: 100
+                },
+                showAutocompleteOnFocus: false
+            });
+        }
     };
 
     this.initializeSync = function () {

--- a/app/assets/javascripts/thesaurus_manager.js
+++ b/app/assets/javascripts/thesaurus_manager.js
@@ -28,6 +28,22 @@ function ThesaurusManager() {
             if ($(this).data('listOfFields').replaceAll(',', '<br/>'))
                 $('.field_listing_theasurus_info').html($(this).data('listOfFields').replaceAll(',', '<br/>'));
         });
+        
+        document_level_binding_element('#assignment_option_custom_thesaurus_record', 'change', function () {
+            if ($(this).val() == 0) {
+                $('assign_thesaurus_to_vocab_dropdown').fadeIn('10');
+            } else {
+                $('assign_thesaurus_to_vocab_dropdown').fadeOut('10');
+            }
+            $('.assign_thesaurus_to_vocab_dropdown').fadeOut('10');
+            let data = {
+                js_action: 'field_list',
+                action: 'fieldList',
+                thesaurus_id: $('#selected_file_t').val(),
+                interview_id: $(this).val()
+            };
+            appHelper.classAction($(this).data('url'), data, 'HTML', 'GET', '', that, true);
+        });
 
         document_level_binding_element('#assignment_option_custom_thesaurus', 'change', function () {
             if ($(this).val() == 0) {

--- a/app/controllers/indexes_controller.rb
+++ b/app/controllers/indexes_controller.rb
@@ -166,7 +166,14 @@ class IndexesController < ApplicationController
     @collection_resource = CollectionResource.find(@resource_file.collection_resource_id)
     @file_index = FileIndex.find(params[:file_index_id])
     @file_index_point = FileIndexPoint.find(params[:file_index_point_id])
+    set_thesaurus
     render template: 'interviews/interview_index/edit'
+  end
+
+  def set_thesaurus
+    thesaurus_settings = ThesaurusSetting.where(organization_id: current_organization.id, is_global: true, thesaurus_type: 'resource').try(:first)
+    @thesaurus_keywords = thesaurus_settings.thesaurus_keywords if thesaurus_settings.present?
+    @thesaurus_subjects = thesaurus_settings.thesaurus_subjects if thesaurus_settings.present?
   end
 
   # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/controllers/interviews/interview_index_controller.rb
+++ b/app/controllers/interviews/interview_index_controller.rb
@@ -27,7 +27,7 @@ module Interviews
     end
 
     def set_thesaurus
-      thesaurus_settings = ThesaurusSetting.where(organization_id: current_organization.id, is_global: true).try(:first)
+      thesaurus_settings = ThesaurusSetting.where(organization_id: current_organization.id, is_global: true, thesaurus_type: 'index').try(:first)
       if @interview.thesaurus_keywords == 0
         if thesaurus_settings.present?
           @interview.thesaurus_keywords = thesaurus_settings.thesaurus_keywords

--- a/app/controllers/interviews/managers_controller.rb
+++ b/app/controllers/interviews/managers_controller.rb
@@ -276,6 +276,8 @@ module Interviews
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def interview_params
+      params[:interviews_interview][:keywords] = params[:interviews_interview][:keywords].split('; ')
+      params[:interviews_interview][:subjects] = params[:interviews_interview][:subjects].split('; ')
       params.require(:interviews_interview).permit(:title, :accession_number, :interview_date, :date_non_preferred_format, :collection_id, :collection_name, :collection_link, :series_id, :series, :series_link,
                                                    :summary, :thesaurus_keywords, :thesaurus_subjects, :thesaurus_titles, :transcript_sync_data, :transcript_sync_data_translation, :media_format, :media_host, :media_url,
                                                    :media_duration, :media_filename, :media_type, :right_statement, :usage_statement, :acknowledgment, :language_info, :include_language, :language_for_translation, :miscellaneous_cms_record_id,

--- a/app/controllers/thesaurus/manager_controller.rb
+++ b/app/controllers/thesaurus/manager_controller.rb
@@ -64,6 +64,21 @@ module Thesaurus
       @selected_file = params['thesaurus_id']
       @action_type = params['action_type']
       if params['list_of_fields_dropdown'].present?
+        if params['assignment_option_custom_thesaurus_resource'].present?
+          thesaurus_settings = ThesaurusSetting.find_or_create_by(organization_id: current_organization.id, is_global: true, thesaurus_type: 'resource')
+          if params['assignment_option_custom_thesaurus'].to_i.positive?
+            if params['assignment_option_custom_thesaurus_resource'] == 'keywords'
+              thesaurus_settings.thesaurus_keywords = 0
+            else
+              thesaurus_settings.thesaurus_subjects = 0
+            end
+          elsif params['assignment_option_custom_thesaurus_resource'] == 'keywords'
+            thesaurus_settings.thesaurus_keywords = params['selected_file'].to_i
+          else
+            thesaurus_settings.thesaurus_subjects = params['selected_file'].to_i
+          end
+          thesaurus_settings.save
+        end
         system_name, option_selected = params['list_of_fields_dropdown'].split('||-@||')
         if @resource_fields_settings[system_name].present?
           if params['assignment_option_custom_thesaurus'].to_s == '0'
@@ -79,7 +94,7 @@ module Thesaurus
         end
       end
       if params['assignment_option_custom_thesaurus_index'].present?
-        thesaurus_settings = ThesaurusSetting.find_or_create_by(organization_id: current_organization.id, is_global: true)
+        thesaurus_settings = ThesaurusSetting.find_or_create_by(organization_id: current_organization.id, is_global: true, thesaurus_type: 'index')
         if params['assignment_option_custom_thesaurus'].to_i.positive?
           if params['assignment_option_custom_thesaurus_index'] == 'keywords'
             thesaurus_settings.thesaurus_keywords = 0
@@ -87,6 +102,24 @@ module Thesaurus
             thesaurus_settings.thesaurus_subjects = 0
           end
         elsif params['assignment_option_custom_thesaurus_index'] == 'keywords'
+          thesaurus_settings.thesaurus_keywords = params['selected_file'].to_i
+        else
+          thesaurus_settings.thesaurus_subjects = params['selected_file'].to_i
+        end
+        thesaurus_settings.save
+        flash[:notice] = t('updated_successfully')
+        redirect_back(fallback_location: root_path)
+        return
+      end
+      if params['assignment_option_custom_thesaurus_record'].present?
+        thesaurus_settings = ThesaurusSetting.find_or_create_by(organization_id: current_organization.id, is_global: true, thesaurus_type: 'record')
+        if params['assignment_option_custom_thesaurus'].to_i.positive?
+          if params['assignment_option_custom_thesaurus_record'] == 'keywords'
+            thesaurus_settings.thesaurus_keywords = 0
+          else
+            thesaurus_settings.thesaurus_subjects = 0
+          end
+        elsif params['assignment_option_custom_thesaurus_record'] == 'keywords'
           thesaurus_settings.thesaurus_keywords = params['selected_file'].to_i
         else
           thesaurus_settings.thesaurus_subjects = params['selected_file'].to_i
@@ -159,13 +192,11 @@ module Thesaurus
 
     def export
       authorize! :manage, current_organization
-      row = []
       all_terms = ::Thesaurus::ThesaurusTerms.where(thesaurus_information_id: @thesaurus.id)
       thesaurus = CSV.generate do |csv|
         all_terms.each do |single_term|
-          row << single_term.term.strip
+          csv << [single_term.term]
         end
-        csv << row
       end
       send_data thesaurus, filename: "#{@thesaurus.title.delete(' ')}_thesaurus_#{Date.today}.csv", type: 'csv'
     end
@@ -232,7 +263,7 @@ module Thesaurus
 
     def over_write_terms(file, thesaurus)
       thesaurus_terms = if file.present?
-                          file.respond_to?(:read) ? file.read.parse_csv.map(&:strip) : []
+                          file.respond_to?(:read) ? CSV.foreach(file.path).map { |row| row[0] } : []
                         else
                           []
                         end
@@ -243,7 +274,7 @@ module Thesaurus
 
     def append_terms(file, thesaurus)
       thesaurus_terms = if file.present?
-                          file.respond_to?(:read) ? file.read.parse_csv.map(&:strip) : []
+                          file.respond_to?(:read) ? CSV.foreach(file.path).map { |row| row[0] } : []
                         else
                           []
                         end

--- a/app/views/interviews/interview_index/_inner_form.html.erb
+++ b/app/views/interviews/interview_index/_inner_form.html.erb
@@ -72,10 +72,16 @@
   <div class="d-flex">
     <div class="form-group">
       <div class="field-title"><%= f.label :keywords, "Keywords" %></div>
-      <%= f.text_area :keywords, required: false, label: false, class: 'form-control keywords tokenfield tokenfield_keywords', data: { items: @interview.present? ? Thesaurus::ThesaurusTerms.where(thesaurus_information_id: @interview.thesaurus_keywords).sort_by(&:term).map(&:term) : [] } %>
+      <%= f.text_area :keywords, required: false, label: false, class: 'form-control keywords tokenfield tokenfield_keywords', data: { items: @interview.present? ? Thesaurus::ThesaurusTerms.where(thesaurus_information_id: @interview.thesaurus_keywords).sort_by(&:term).map(&:term) : @thesaurus_keywords.present? ? Thesaurus::ThesaurusTerms.where(thesaurus_information_id: @thesaurus_keywords).sort_by(&:term).map(&:term) : [] } %>
       <small class="form-text text-muted mt-1">Keywords should be separated by a semi-colon.</small>
       <% if @interview.present? %>
         <% thesaurus = Thesaurus::Thesaurus.where(id: @interview.thesaurus_keywords) %>
+        <% if thesaurus.length.positive? %>
+          <small class="form-text text-muted mt-1">Current Thesaurus: <strong><%= thesaurus.first.title %></strong></small>
+        <% end %>
+      <% end %>
+      <% if @thesaurus_keywords.present? %>
+        <% thesaurus = Thesaurus::Thesaurus.where(id: @thesaurus_keywords) %>
         <% if thesaurus.length.positive? %>
           <small class="form-text text-muted mt-1">Current Thesaurus: <strong><%= thesaurus.first.title %></strong></small>
         <% end %>
@@ -84,10 +90,16 @@
     <% if @interview.present? &&  @interview.include_language %>
       <div class="form-group">
         <div class="field-title"><%= f.label :keywords, "Keywords" %></div>
-        <%= f.text_area :keywords_alt, required: false, label: false, class: 'form-control keywords tokenfield tokenfield_keywords', data: { items: @interview.present? ? Thesaurus::ThesaurusTerms.where(thesaurus_information_id: @interview.thesaurus_keywords).sort_by(&:term).map(&:term) : [] } %>
+        <%= f.text_area :keywords_alt, required: false, label: false, class: 'form-control keywords tokenfield tokenfield_keywords', data: { items: @interview.present? ? Thesaurus::ThesaurusTerms.where(thesaurus_information_id: @interview.thesaurus_keywords).sort_by(&:term).map(&:term) : @thesaurus_keywords.present? ? Thesaurus::ThesaurusTerms.where(thesaurus_information_id: @thesaurus_keywords).sort_by(&:term).map(&:term) : [] } %>
         <small class="form-text text-muted mt-1">Keywords should be separated by a semi-colon.</small>
         <% if @interview.present? %>
           <% thesaurus = Thesaurus::Thesaurus.where(id: @interview.thesaurus_keywords) %>
+          <% if thesaurus.length.positive? %>
+            <small class="form-text text-muted mt-1">Current Thesaurus: <strong><%= thesaurus.first.title %></strong></small>
+          <% end %>
+        <% end %>
+        <% if @thesaurus_keywords.present? %>
+          <% thesaurus = Thesaurus::Thesaurus.where(id: @thesaurus_keywords) %>
           <% if thesaurus.length.positive? %>
             <small class="form-text text-muted mt-1">Current Thesaurus: <strong><%= thesaurus.first.title %></strong></small>
           <% end %>
@@ -98,10 +110,16 @@
   <div class="d-flex">
     <div class="form-group">
       <div class="field-title"><%= f.label :subjects, "Subjects" %></div>
-      <%= f.text_area :subjects, required: false, label: false, class: 'form-control subjects tokenfield tokenfield_subjects', data: { items: @interview.present? ? Thesaurus::ThesaurusTerms.where(thesaurus_information_id: @interview.thesaurus_subjects).sort_by(&:term).map(&:term) : [] } %>
+      <%= f.text_area :subjects, required: false, label: false, class: 'form-control subjects tokenfield tokenfield_subjects', data: { items: @interview.present? ? Thesaurus::ThesaurusTerms.where(thesaurus_information_id: @interview.thesaurus_subjects).sort_by(&:term).map(&:term) : @thesaurus_keywords.present? ? Thesaurus::ThesaurusTerms.where(thesaurus_information_id: @thesaurus_subjects).sort_by(&:term).map(&:term) : [] } %>
       <small class="form-text text-muted mt-1">Subjects should be separated by a semi-colon.</small>
       <% if @interview.present? %>
         <% thesaurus = Thesaurus::Thesaurus.where(id: @interview.thesaurus_subjects) %>
+        <% if thesaurus.length.positive? %>
+          <small class="form-text text-muted mt-1">Current Thesaurus: <strong><%= thesaurus.first.title %></strong></small>
+        <% end %>
+      <% end %>
+      <% if @thesaurus_subjects.present? %>
+        <% thesaurus = Thesaurus::Thesaurus.where(id: @thesaurus_subjects) %>
         <% if thesaurus.length.positive? %>
           <small class="form-text text-muted mt-1">Current Thesaurus: <strong><%= thesaurus.first.title %></strong></small>
         <% end %>
@@ -110,10 +128,16 @@
     <% if @interview.present? &&  @interview.include_language %>
       <div class="form-group">
         <div class="field-title"><%= f.label :subjects, "Subjects" %></div>
-        <%= f.text_area :subjects_alt, required: false, label: false, class: 'form-control subjects tokenfield tokenfield_subjects', data: { items: @interview.present? ? Thesaurus::ThesaurusTerms.where(thesaurus_information_id: @interview.thesaurus_subjects).sort_by(&:term).map(&:term) : [] } %>
+        <%= f.text_area :subjects_alt, required: false, label: false, class: 'form-control subjects tokenfield tokenfield_subjects', data: { items: @interview.present? ? Thesaurus::ThesaurusTerms.where(thesaurus_information_id: @interview.thesaurus_subjects).sort_by(&:term).map(&:term) : @thesaurus_keywords.present? ? Thesaurus::ThesaurusTerms.where(thesaurus_information_id: @thesaurus_subjects).sort_by(&:term).map(&:term) : [] } %>
         <small class="form-text text-muted mt-1">Subjects should be separated by a semi-colon.</small>
         <% if @interview.present? %>
           <% thesaurus = Thesaurus::Thesaurus.where(id: @interview.thesaurus_subjects) %>
+          <% if thesaurus.length.positive? %>
+            <small class="form-text text-muted mt-1">Current Thesaurus: <strong><%= thesaurus.first.title %></strong></small>
+          <% end %>
+        <% end %>
+        <% if @thesaurus_subjects.present? %>
+          <% thesaurus = Thesaurus::Thesaurus.where(id: @thesaurus_subjects) %>
           <% if thesaurus.length.positive? %>
             <small class="form-text text-muted mt-1">Current Thesaurus: <strong><%= thesaurus.first.title %></strong></small>
           <% end %>

--- a/app/views/interviews/managers/_form.html.erb
+++ b/app/views/interviews/managers/_form.html.erb
@@ -1,3 +1,6 @@
+<%
+thesaurus_settings = ThesaurusSetting.where(organization_id: current_organization.id, is_global: true, thesaurus_type: 'record').try(:first)
+%>
 <%= simple_form_for @interview, :url => @interview.new_record? ? ohms_records_path : interviews_manager_path(@interview), html: { class: "interview_manager" } do |f| %>
   <div class="row ">
     <div class="breadcrumb mt-4 mb-3">
@@ -137,51 +140,31 @@
           </div>
           <div class="form-group">
             <div class="field-title"><%= f.label :keywords %>
-              <a href="javascript:void(0);" class="add_keywords add_button_interview text-decoration-none"> +</a>
             </div>
             <div class="container_keywords">
-              <% if @interview.keywords.present? && @interview.keywords.size > 0 %>
-                <% @interview.keywords.each do |single_keywords| %>
-                  <div class="row container_keywords_inner field_container">
-                    <div class="col-12 mb-2">
-                      <input type='text' name='interviews_interview[keywords][]' id="interviews_interview_keywords" value="<%= single_keywords %>" class="json optional form-control keywords"/>
-                      <a href="javascript://" class="remove_keywords" title="Remove keywords"><i class="remove_icon_image"></i></a>
-                    </div>
-                  </div>
+              <% @interview.keywords = @interview.keywords.join(';')%>
+              <%= f.text_area :keywords, required: false, label: false, class: 'form-control keywords tokenfield tokenfield_keywords', data: { items: thesaurus_settings.present? ? Thesaurus::ThesaurusTerms.where(thesaurus_information_id: thesaurus_settings.thesaurus_keywords).sort_by(&:term).map(&:term) : [] } %>
+              <small class="form-text text-muted mt-1">Keywords should be separated by a semi-colon.</small>
+              <% if thesaurus_settings.present? && thesaurus_settings.thesaurus_keywords.positive? %>
+                <% thesaurus = Thesaurus::Thesaurus.where(id: thesaurus_settings.thesaurus_keywords) %>
+                <% if thesaurus.length.positive? %>
+                  <small class="form-text text-muted mt-1">Current Thesaurus: <strong><%= thesaurus.first.title %></strong></small>
                 <% end %>
-              <% else %>
-
-                <div class="row container_keywords_inner field_container">
-                  <div class="col-12 mb-2">
-                    <input type='text' name='interviews_interview[keywords][]' id="interviews_interview_keywords" class="json optional form-control keywords "/>
-                    <a href="javascript://" class="remove_keywords" title="Remove keywords"><i class="remove_icon_image"></i></a>
-                  </div>
-                </div>
               <% end %>
             </div>
           </div>
           <div class="form-group">
             <div class="field-title"><%= f.label :subjects %>
-              <a href="javascript:void(0);" class="add_subjects add_button_interview text-decoration-none"> +
-              </a>
             </div>
             <div class="container_subjects">
-              <% if @interview.subjects.present? && @interview.subjects.size > 0 %>
-                <% @interview.subjects.each do |single_subjects| %>
-                  <div class="row container_subjects_inner field_container">
-                    <div class="col-12 mb-2">
-                      <input type='text' name='interviews_interview[subjects][]' id="interviews_interview_subjects" value='<%= single_subjects %>' class="json optional form-control subjects "/>
-                      <a href="javascript://" class="remove_subjects" title="Remove subjects"><i class="remove_icon_image"></i></a>
-                    </div>
-                  </div>
-                <% end %>
-              <% else %>
-                <div class="row container_subjects_inner field_container">
-                  <div class="col-12 mb-2">
-                    <input type='text' name='interviews_interview[subjects][]' id="interviews_interview_subjects" class="json optional form-control subjects "/>
-                    <a href="javascript://" class="remove_subjects" title="Remove subjects"><i class="remove_icon_image"></i></a>
-                  </div>
-                </div>
+              <% @interview.subjects = @interview.subjects.join(';')%>
+              <%= f.text_area :subjects, required: false, label: false, class: 'form-control subjects tokenfield tokenfield_subjects', data: { items: thesaurus_settings.present? ? Thesaurus::ThesaurusTerms.where(thesaurus_information_id: thesaurus_settings.thesaurus_subjects).sort_by(&:term).map(&:term) : [] } %>
+              <small class="form-text text-muted mt-1">Subjects should be separated by a semi-colon.</small>
+              <% if thesaurus_settings.present? && thesaurus_settings.thesaurus_subjects.positive? %>
+                <% thesaurus = Thesaurus::Thesaurus.where(id: thesaurus_settings.thesaurus_subjects) %>
+                <% if thesaurus.length.positive? %>
+                  <small class="form-text text-muted mt-1">Current Thesaurus: <strong><%= thesaurus.first.title %></strong></small>
+                 <% end %>
               <% end %>
             </div>
           </div>

--- a/app/views/organization_fields/index.html.erb
+++ b/app/views/organization_fields/index.html.erb
@@ -504,6 +504,18 @@
               </div>
             </div>
           </div>
+          <div class="row  mt-3">
+              <div class="col-12">
+                <div class="field-title">
+                  <label> OHMS Resource Metadata Field <button type="button" class="info-btn" data-toggle="tooltip" data-placement="right" title="Selecting a thesaurus here will apply that thesaurus to that specific metadata field on the Index Editor page for all Aviary indexes."></button></label>
+                </div>
+                <select id='assignment_option_custom_thesaurus_resource' name='assignment_option_custom_thesaurus_resource' placeholder="" data-url="<%= assignment_management_thesaurus_manager_index_path %>">
+                  <option value="">Select option</option>
+                  <option value="keywords">Keywords</option>
+                  <option value="subjects">Subjects</option>
+                </select>
+              </div>
+            </div>
           <div class="row mt-3">
             <div class="col-12" id='assign_thesaurus_to_vocab_dropdown'>
               <div class="field-title">
@@ -521,6 +533,18 @@
             </div>
           </div>
           <% else %>
+            <div class="row  mt-3">
+              <div class="col-12">
+                <div class="field-title">
+                  <label> OHMS Record Metadata Field <button type="button" class="info-btn" data-toggle="tooltip" data-placement="right" title="Selecting a thesaurus here will apply that thesaurus to that metadata field in the OHMS Studio Metadata Editor for all OHMS records."></button></label>
+                </div>
+                <select id='assignment_option_custom_thesaurus_record' name='assignment_option_custom_thesaurus_record' placeholder="" data-url="<%= assignment_management_thesaurus_manager_index_path %>">
+                  <option value="">Select option</option>
+                  <option value="keywords">Keywords</option>
+                  <option value="subjects">Subjects</option>
+                </select>
+              </div>
+            </div>
             <div class="row">
               <div class="col-12">
                 <div class="field-title">

--- a/app/views/thesaurus/manager/_form.html.erb
+++ b/app/views/thesaurus/manager/_form.html.erb
@@ -20,7 +20,7 @@
             </div>
             <a href='<%= thesaurus_manager_export_path(@thesaurus) %>' class="float-right btn-sm btn-default mb-5px"> Download Thesaurus</a>
             <% all_terms = Thesaurus::ThesaurusTerms.where(thesaurus_information_id: @thesaurus.id).limit(500) %>
-            <textarea class="form-control ohms_integrations_terms" readonly><%= all_terms.pluck(:term).join(',') %><%= count > 100 ? '...' : '' %></textarea> 
+            <textarea class="form-control ohms_integrations_terms" readonly><%= all_terms.pluck(:term).join('||') %><%= count > 100 ? '...' : '' %></textarea> 
           </div>
         </div>
       <% end %>

--- a/db/migrate/20220728081606_add_type_to_thesaurus_settings.rb
+++ b/db/migrate/20220728081606_add_type_to_thesaurus_settings.rb
@@ -1,0 +1,5 @@
+class AddTypeToThesaurusSettings < ActiveRecord::Migration[6.1]
+  def change
+    add_column :thesaurus_settings, :thesaurus_type, :string, default: "index"
+  end
+end


### PR DESCRIPTION
- [x] [AVIARY-3238](https://jira.weareavp.com/browse/AVIARY-3238) Change input specs for Custom Thesaurus CSV file
- [x] [AVIARY-3217](https://jira.weareavp.com/browse/AVIARY-3217) As an Aviary Org User, I can Assign an Aviary Thesaurus to an Aviary Index Field for all Aviary Indexes
- [x] [AVIARY-3219](https://jira.weareavp.com/browse/AVIARY-3219) As an OHMS User, I can Assign an OHMS Thesaurus to an OHMS Record Metadata Editor Field for all OHMS Records from the OHMS Thesaurus Manager