### PR TITLE
Sprint 129 - Public Changes

### DIFF
--- a/app/assets/javascripts/interview_index_manager.js
+++ b/app/assets/javascripts/interview_index_manager.js
@@ -338,20 +338,26 @@ function InterviewIndexManager() {
             
 
         });
-        document_level_binding_element('.delete_index', 'click', function () {
 
+        document_level_binding_element('.delete_index', 'click', function () {
             $('#modalPopupFooterYes').attr('href', $(this).data().url);
             let message = 'Are you sure you want to remove this index point?';
             $('#modalPopupBody').html(message);
             $('#modalPopupTitle').html('Delete "' + $(this).data().name + '"');
             $('#modalPopup').modal('show');
         });
-        document_level_binding_element('.simple_form', 'change', function () {
+
+        document_level_binding_element('.simple_form', 'change, keyup', function () {
             formChange = 1;
         });
-        document_level_binding_element('.btn-primary', 'click', function () {
-            formChange = 0;
+
+        document_level_binding_element('.simple_form', 'submit', function (e) {
+          e.preventDefault();
+
+          formChange = 0;
+          this.submit();
         });
+
         document_level_binding_element('.play-timecode', 'click', function () {
             let currentTime = $(this).data().timecode;
             if ($('#avalon_widget').length > 0) {

--- a/app/assets/stylesheets/collection_resource.css
+++ b/app/assets/stylesheets/collection_resource.css
@@ -316,8 +316,18 @@ h5.MsoNormal span {
 }
 
 .internal-field {
-  color: #545454;
-  background-color: #f7f7f7;
-  border: 1px solid #e1e1e1;
-  margin-right: 15px;
+    color: #545454;
+    background-color: #f7f7f7;
+    border: 1px solid #ecf0f4;
+    margin: 10px 10px 10px 0;
+    border-radius: 6px;
+    display: flex;
+}
+
+.internal-field dt {
+    width: 21%;
+}
+
+.internal-field dd {
+    width: 79%;
 }

--- a/app/assets/stylesheets/organization.scss
+++ b/app/assets/stylesheets/organization.scss
@@ -789,3 +789,7 @@
 .justify-content strong{
   min-width: 175px;
 }
+
+.contrast-warning {
+  font-size: smaller;
+}

--- a/app/assets/stylesheets/search-details.scss
+++ b/app/assets/stylesheets/search-details.scss
@@ -429,7 +429,7 @@
   font-size: 14px;
   line-height: 19px;
   font-weight: bold;
-  padding: 15px 10px 0 7px;
+  padding: 15px 10px 15px 7px;
   width: 21%;
   float: left;
   word-break: break-word;

--- a/app/assets/stylesheets/search-page.scss
+++ b/app/assets/stylesheets/search-page.scss
@@ -737,7 +737,7 @@ form.range_limit .hold input:nth-child(2) {
 }
 
 .search-result-visual {
-    background: #26ff00 !important;
+    background: #336175;
     padding: 55px 20px 40px;
     color: #f3f3f3;
     z-index: 3;
@@ -746,8 +746,7 @@ form.range_limit .hold input:nth-child(2) {
     position: relative;
     font-weight: 100;
     text-align: center;
-    background-repeat: no-repeat !important;
-    background-size: cover !important;
+    background-repeat: no-repeat;
     margin-bottom: 20px;
     min-height: 135px;
 }

--- a/app/assets/stylesheets/search-page.scss
+++ b/app/assets/stylesheets/search-page.scss
@@ -737,7 +737,7 @@ form.range_limit .hold input:nth-child(2) {
 }
 
 .search-result-visual {
-    background: #336175;
+    background: #26ff00 !important;
     padding: 55px 20px 40px;
     color: #f3f3f3;
     z-index: 3;
@@ -746,7 +746,8 @@ form.range_limit .hold input:nth-child(2) {
     position: relative;
     font-weight: 100;
     text-align: center;
-    background-repeat: no-repeat;
+    background-repeat: no-repeat !important;
+    background-size: cover !important;
     margin-bottom: 20px;
     min-height: 135px;
 }

--- a/app/controllers/concerns/aviary/manage_organization.rb
+++ b/app/controllers/concerns/aviary/manage_organization.rb
@@ -21,6 +21,15 @@ module Aviary::ManageOrganization
     authorize! :manage, current_organization
   end
 
+  def color_contrast
+    authorize! :manage, current_organization
+
+    banner_contrast = fetch_contrast(params[:banner_title_color], params[:search_background_color])
+    search_contrast = fetch_contrast(params[:saarch_font_color], params[:search_background_color])
+
+    render json: { banner_contrast: banner_contrast['AAALarge'], search_contrast: search_contrast['AAA'] }
+  end
+
   def update
     authorize! :manage, current_organization unless admin_signed_in?
     if @organization.update(org_params)
@@ -69,5 +78,18 @@ module Aviary::ManageOrganization
                                          :banner_title_text, :banner_type, :banner_slider_resources, :default_tab_selection,
                                          :title_font_color, :title_font_family, :title_font_size, :favicon, :hide_on_home,
                                          :custom_domain, :custom_url_for_resource, :search_panel_bg_color, :search_panel_font_color)
+  end
+
+  def fetch_contrast(fcolor, bcolor)
+    params = { fcolor: fcolor, bcolor: bcolor, api: '' }
+    uri = 'https://webaim.org/resources/contrastchecker/'
+
+    response = Curl.get(uri, params)
+
+    begin
+      JSON.parse(response.body)
+    rescue JSON::ParserError
+      nil
+    end
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -12,11 +12,17 @@ class HomeController < ApplicationController
                                      indexes: [], keywords: [], op: [], resource_description: [],
                                      search_field: 'advanced', search_type: 'simple', title_text: '',
                                      transcript: [], type_of_search: ['simple'])
+      return
     end
+
     title_bread_crumb = organization.present? ? "Back to <strong>#{organization.name.truncate(25, omission: '...')}</strong>" : 'Back to Aviary Home'
     record_last_bread_crumb(request.fullpath, title_bread_crumb)
     HomePresenter.manage_home_tracking(cookies, organization, session, ahoy)
     cookies[:update_pop_bypass] = true if params[:update_pop_bypass]
+
+    if organization.present? && organization.default_tab_selection == 'collections' && request.fullpath == '/'
+      redirect_to org_collection_url
+    end
   end
 
   def featured_collections

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -20,9 +20,9 @@ class HomeController < ApplicationController
     HomePresenter.manage_home_tracking(cookies, organization, session, ahoy)
     cookies[:update_pop_bypass] = true if params[:update_pop_bypass]
 
-    if organization.present? && organization.default_tab_selection == 'collections' && request.fullpath == '/'
-      redirect_to org_collection_url
-    end
+    return unless organization.present? && organization.default_tab_selection == 'collections' && request.fullpath == '/'
+
+    redirect_to org_collection_url
   end
 
   def featured_collections

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -5,7 +5,7 @@
 # Aviary is an audiovisual content publishing platform with sophisticated features for search and permissions controls.
 # Copyright (C) 2019 Audio Visual Preservation Solutions, Inc.
 class OrganizationsController < ApplicationController
-  before_action :set_organization, only: %I[edit update show display_settings autocomplete_resources]
+  before_action :set_organization, only: %I[edit update show display_settings color_contrast autocomplete_resources]
   before_action :authenticate_user!, except: %I[index show confirm_invite]
   include Aviary::ManageOrganization
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -105,6 +105,7 @@ module ApplicationHelper
   end
 
   def time_to_duration(seconds, mili_seconds = false)
+    seconds = seconds.to_f
     hours = seconds / 3600
     minutes = (seconds % 3600) / 60
     remaining_seconds = seconds % 60

--- a/app/models/collection_resource_file.rb
+++ b/app/models/collection_resource_file.rb
@@ -428,4 +428,13 @@ class CollectionResourceFile < ApplicationRecord
       "collection_id_is #{sort_direction}"
     end
   end
+
+  def reindex_collection_resource_file
+    reload
+
+    Sunspot.index self
+    Sunspot.commit
+
+    collection_resource.reindex_collection_resource
+  end
 end

--- a/app/models/file_transcript.rb
+++ b/app/models/file_transcript.rb
@@ -30,7 +30,7 @@ class FileTranscript < ApplicationRecord
   after_destroy :update_solr
 
   def update_solr
-    collection_resource_file.collection_resource.reindex_collection_resource if should_index?
+    collection_resource_file.reindex_collection_resource_file if should_index?
   end
 
   def should_index?

--- a/app/services/datatables/resources_listing_datatable.rb
+++ b/app/services/datatables/resources_listing_datatable.rb
@@ -74,23 +74,26 @@ class ResourcesListingDatatable < ApplicationDatatable
           end
         end
         links = if %w[permission_group playlist_add_resource].include?(@called_from)
-                  resource['description_identifier_sms'] = resource['description_identifier_sms'].collect { |e| e ? e.to_s.strip : e }
-                  description_identifier_sms = resource['description_identifier_sms'].present? ? truncate(strip_tags(resource['description_identifier_sms'].join(',')).gsub('::', '')) : 'none'
-                  description_date_sms = resource['description_date_sms'].present? ? truncate(strip_tags(resource['description_date_sms'].join(',')).gsub('::', '')) : 'none'
-                  access_ss = resource['access_ss'].present? ? resource['access_ss'].titleize : 'none'
-                  "<a href='javascript:void(0)' data-label='#{strip_tags(resource['title_ss'].to_s.delete('"'))} (#{resource['id_is']})'
-                          data-value='#{strip_tags(resource['title_ss'].to_s.delete('"'))}' data-description_identifier='#{description_identifier_sms}' data-description_date='#{description_date_sms}'
-                          data-access='#{access_ss}' data-id='#{resource['id_is']}' class='btn-sm btn-success add_to_resource_group'>Add</a>"
+                  description_identifier_sms = resource['description_identifier_sms'].to_s.strip.presence || 'none'
+                  description_date_sms = resource['description_date_sms'].to_s.strip.presence || 'none'
+                  access_ss = resource['access_ss'].to_s.titleize.presence || 'none'
+
+                  "<a href='javascript:void(0)' data-label='#{strip_tags(resource['title_ss'].to_s.delete('"'))} (#{resource['id_is']})' \
+                    data-value='#{strip_tags(resource['title_ss'].to_s.delete('"'))}' \
+                    data-description_identifier='#{description_identifier_sms}' data-description_date='#{description_date_sms}' \
+                    data-access='#{access_ss}' data-id='#{resource['id_is']}' class='btn-sm btn-success add_to_resource_group'>Add</a>"
                 else
-                  links_set = '<a href="' + collection_collection_resource_path(resource['collection_id_is'], resource['id_is']) +
-                              '"class="btn-sm btn-default hidden_focus_btn" data-id="collection_resource_view_' + resource['id_is'].to_s + '">View</a>&nbsp;&nbsp;'
-                  links_set += '<a href="' + edit_collection_collection_resource_path(collection_id: resource['collection_id_is'], id: resource['id_is']) +
-                               '"class="btn-sm btn-success hidden_focus_btn" data-id="collection_resource_edit_' + resource['id_is'].to_s + '">Edit</a>&nbsp;&nbsp;'
-                  if CollectionResource.where(id: resource['id_is']).present?
-                    if can? :destroy, CollectionResource.find(resource['id_is'])
-                      links_set += "<a href='javascript://' data-name='#{strip_tags(resource['title_ss'].to_s)}' data-url='#{collection_resource_path(resource['id_is'])}' class='btn-sm btn-danger resource_delete hidden_focus_btn' data-id='collection_resource_delete_" + resource['id_is'].to_s + "' >Delete</a>"
-                    end
+                  links_set = "<a href='#{collection_collection_resource_path(resource['collection_id_is'], resource['id_is'])}' class='btn-sm btn-default hidden_focus_btn' \
+                    data-id='collection_resource_view_#{resource['id_is']}'>View</a>&nbsp;&nbsp;"
+                  links_set += "<a href='#{edit_collection_collection_resource_path(collection_id: resource['collection_id_is'], id: resource['id_is'])}' \
+                    class='btn-sm btn-success hidden_focus_btn' data-id='collection_resource_edit_#{resource['id_is']}'>Edit</a>&nbsp;&nbsp;"
+
+                  if CollectionResource.exists?(resource['id_is']) && can?(:destroy, CollectionResource.find(resource['id_is']))
+                    links_set += "<a href='javascript://' data-name='#{strip_tags(resource['title_ss'].to_s)}' \
+                      data-url='#{collection_resource_path(resource['id_is'])}' \
+                      class='btn-sm btn-danger resource_delete hidden_focus_btn' data-id='collection_resource_delete_#{resource['id_is']}'>Delete</a>"
                   end
+
                   links_set
                 end
         column << links

--- a/app/views/organizations/display_settings.html.erb
+++ b/app/views/organizations/display_settings.html.erb
@@ -119,7 +119,7 @@
             <div class="col-md-6">
               <div class="form-group">
                 <div class="field-title"><label for="">Search Panel Background Color <button type="button" class="info-btn" data-content="This color will be used as the background color behind the search bar on the search resources page. It will also be used as the background color behind the search bar on your organization landing page and your collection landing page if you do not display a banner on those pages."></button></label></div>
-                <%= f.input :search_panel_bg_color, label: false, input_html: { class: 'form-control color_picker', placeholder: 'Font Color' }, :required => true %>
+                <%= f.input :search_panel_bg_color, label: false, input_html: { class: 'form-control color_picker', placeholder: 'Font Color', data: { url: color_contrast_organization_url } }, :required => true %>
               </div>
             </div>
             <div class="col-md-6">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -142,6 +142,7 @@ Rails.application.routes.draw do
   resources :organizations, only: %i[index show update]
   get '/organization_profile', to: 'organizations#edit', as: :edit_organization
   get '/display_settings', to: 'organizations#display_settings', as: :display_settings_organization
+  get :color_contrast, to: 'organizations#color_contrast', as: :color_contrast_organization
   match '/search_configuration', to: 'organizations#search_configuration', as: :search_configuration_organization, via: %i[get post]
   post '/set_layout', to: 'home#set_layout'
   scope :public_access_urls do


### PR DESCRIPTION
- [x] Aviary-3706: The organization home page will now redirect to the `org_collection` url if the default tab is set to `collections`
- [x] Aviary-3722: Show color contrast warnings, if needed on the organization, display settings page
- [x] Aviary-3722: Show warning if `Banner Title Text Color` and `Search Panel Background Color` does not have sufficient contrast
- [x] Aviary-3722: Show warning if `Search Panel Font Color` and `Search Panel Background Color` does not have sufficient contrast
- [x] Aviary-3728: Fixed a bug that prevented transcript count from updating on the `collection_resource_file` on Solr
- [x] Aviary-3729: Fixed resource list not populating while trying to add resources to a playlist
- [x] Aviary-3735: Removed leave site prompt on form submit. 
- [x] Aviary-3737: Improved styling for internal fields on resource and media file metadata
- [x] Aviary-3738: Fixed bug which showed duration as `00:00:00` everywhere