### PR TITLE
Sprint 130

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 - gem update bundler
 - gem install bundler
 before_script:
-- curl -sSL https://raw.githubusercontent.com/moliware/travis-solr/master/travis-solr.sh | SOLR_VERSION=7.5.0 SOLR_COLLECTION=test SOLR_COLLECTION_CONF=solr/configsets/sunspot/conf bash
+- curl -sSL https://raw.githubusercontent.com/UsmanLhrPk/travis-solr/master/travis-solr.sh | SOLR_VERSION=9.3.0 SOLR_COLLECTION=test SOLR_COLLECTION_CONF=solr/configsets/sunspot/conf bash
 - RAILS_ENV=test bundle exec rake db:create
 - RAILS_ENV=test bundle exec rake db:migrate
 script:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,15 +147,16 @@ GEM
     bindex (0.8.1)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
-    blacklight (7.22.2)
+    blacklight (7.33.1)
       deprecation
       globalid
+      hashdiff
       i18n (>= 1.7.0)
       jbuilder (~> 2.7)
       kaminari (>= 0.15)
       ostruct (>= 0.3.2)
-      rails (>= 5.1, < 7)
-      view_component (~> 2.42)
+      rails (>= 5.1, < 7.1)
+      view_component (~> 2.66)
     blacklight_advanced_search (7.0.0)
       blacklight (~> 7.0)
       parslet
@@ -368,6 +369,7 @@ GEM
     globalid (1.1.0)
       activesupport (>= 5.0)
     hana (1.3.7)
+    hashdiff (1.0.1)
     hashie (5.0.0)
     hiredis (0.6.3)
     htmlentities (4.3.4)
@@ -502,7 +504,7 @@ GEM
       rake
     mini_magick (4.11.0)
     mini_mime (1.1.2)
-    minitest (5.18.1)
+    minitest (5.19.0)
     model_attribute (3.2.0)
     momentjs-rails (2.29.1.1)
       railties (>= 3.1)
@@ -511,7 +513,7 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     mysql2 (0.5.3)
-    net-imap (0.3.6)
+    net-imap (0.3.7)
       date
       net-protocol
     net-pop (0.1.2)
@@ -535,11 +537,11 @@ GEM
     noid-rails (3.0.3)
       actionpack (>= 5.0.0, < 7)
       noid (~> 0.9)
-    nokogiri (1.15.2-arm64-darwin)
+    nokogiri (1.15.3-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.15.2-x86_64-darwin)
+    nokogiri (1.15.3-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.15.2-x86_64-linux)
+    nokogiri (1.15.3-x86_64-linux)
       racc (~> 1.4)
     oga (3.3)
       ast
@@ -560,7 +562,7 @@ GEM
     open_uri_redirections (0.2.1)
     orm_adapter (0.5.0)
     os (1.0.1)
-    ostruct (0.5.2)
+    ostruct (0.5.5)
     parallel (1.21.0)
     paranoia (2.5.0)
       activerecord (>= 5.1, < 7.1)
@@ -583,7 +585,7 @@ GEM
     puma (5.6.5)
       nio4r (~> 2.0)
     racc (1.7.1)
-    rack (2.2.7)
+    rack (2.2.8)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-attack (6.6.0)
@@ -875,7 +877,7 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (~> 4.0)
-    websocket-driver (0.7.5)
+    websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     wicked_pdf (2.1.0)
@@ -889,7 +891,7 @@ GEM
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yomu (0.1.5)
-    zeitwerk (2.6.8)
+    zeitwerk (2.6.10)
 
 PLATFORMS
   arm64-darwin-21

--- a/app/assets/javascripts/datatables.js
+++ b/app/assets/javascripts/datatables.js
@@ -11,7 +11,7 @@
 // require datatables/extensions/ColReorder/dataTables.colReorder
 //= require datatables/extensions/FixedColumns/dataTables.fixedColumns
 //= require datatables/extensions/FixedHeader/dataTables.fixedHeader
-// require datatables/extensions/KeyTable/dataTables.keyTable
+//= require datatables/extensions/KeyTable/dataTables.keyTable
 // require datatables/extensions/Responsive/dataTables.responsive
 // require datatables/extensions/RowGroup/dataTables.rowGroup
 // require datatables/extensions/RowReorder/dataTables.rowReorder
@@ -29,6 +29,7 @@
 // Do not show alert popup in any case. Always throw an error to the console
 $.fn.dataTable.ext.errMode = 'throw';
 $.extend( $.fn.dataTable.defaults, {
+  keys: true,
   responsive: true,
   pagingType: 'full',
   //dom:

--- a/app/assets/javascripts/interview_index_manager.js
+++ b/app/assets/javascripts/interview_index_manager.js
@@ -26,66 +26,58 @@ function InterviewIndexManager() {
         host = $('#media_host').data('host')
         if($('.tokenfield').length > 0){
             const keywords_options = {
-                el: document.querySelector('.tokenfield_keywords'),
-                multiple: true,
-                minChars: 1,
-                itemName: 'keywords',
-                setItems: $('.tokenfield_keywords').data('selectedKeys'),
-                delimiters: [';', 'Tab', 'Enter', 'Numpad Enter']
-            };
+                minLength: 1,
+                delimiter: [';', 'Tab', 'Enter', 'Numpad Enter'],
+                beautify: true,
+            }
 
             if ($('.tokenfield_keywords').data('path') !== undefined) {
-                keywords_options.remote = {
-                    url: $('.tokenfield_keywords').data('path'),
-                    type: 'GET',
-                    queryParam: 'term',
-                    params: {
-                        tId: $('.tokenfield_keywords').data('tId'),
-                        typeOfList: $('.tokenfield_keywords').data('typeOfList')
-                    }
-                };
-                keywords_options.newItems = false;
-                keywords_options.itemLabel = 'label';
-                keywords_options.itemValue = 'value';
-                keywords_options.itemData = 'label';
-                keywords_options.maxSuggest = parseInt($('.tokenfield_keywords').data('maxSuggest'), 10);
-            } else {
-                keywords_options.newItems = true;
-                keywords_options.newItemName = 'keywords';
+                keywords_options.autocomplete = {
+                    source: function( request, response ) {
+                        $.ajax({
+                            url: $('.tokenfield_keywords').data('path'),
+                            dataType: "json",
+                            data: {
+                                term: request.term,
+                                tId: $('.tokenfield_keywords').data('tId'),
+                                typeOfList: $('.tokenfield_keywords').data('typeOfList')
+                            },
+                            success: function( data ) {
+                              response( data );
+                            }
+                        });
+                    },
+                }
             }
 
-            new Tokenfield(keywords_options);
+            $('.tokenfield_keywords').tokenfield(keywords_options);
 
             const subjects_options = {
-              el: document.querySelector('.tokenfield_subjects'),
-              multiple: true,
-              minChars: 1,
-              itemName: 'subjects',
-              setItems: $('.tokenfield_subjects').data('selectedKeys'),
-              delimiters: [';', 'Tab', 'Enter', 'Numpad Enter']
-            };
-
-            if ($('.tokenfield_subjects').data('path') !== undefined) {
-              subjects_options.remote = {
-                  url: $('.tokenfield_subjects').data('path'),
-                  type: 'GET',
-                  queryParam: 'term',
-                  params: {
-                      tId: $('.tokenfield_subjects').data('tId'),
-                      typeOfList: $('.tokenfield_subjects').data('typeOfList')
-                  }
-              };
-              subjects_options.newItems = false;
-              subjects_options.itemLabel = 'label';
-              subjects_options.itemValue = 'value';
-              subjects_options.itemData = 'label';
-              subjects_options.maxSuggest = parseInt($('.tokenfield_keywords').data('maxSuggest'), 10);
-            } else {
-                subjects_options.newItems = true;
-                subjects_options.newItemName = 'subjects';
+                minLength: 1,
+                delimiter: [';', 'Tab', 'Enter', 'Numpad Enter'],
+                beautify: true,
             }
 
-          new Tokenfield(subjects_options);
+            if ($('.tokenfield_subjects').data('path') !== undefined) {
+            subjects_options.autocomplete = {
+                source: function( request, response ) {
+                    $.ajax({
+                        url: $('.tokenfield_subjects').data('path'),
+                        dataType: "json",
+                        data: {
+                            term: request.term,
+                            tId: $('.tokenfield_subjects').data('tId'),
+                            typeOfList: $('.tokenfield_subjects').data('typeOfList')
+                        },
+                        success: function( data ) {
+                          response( data );
+                        }
+                    });
+                },
+            }
+            }
+
+            $('.tokenfield_subjects').tokenfield(subjects_options);
         }
         if($('.no-media').length > 0)
         {

--- a/app/assets/javascripts/interview_manager.js
+++ b/app/assets/javascripts/interview_manager.js
@@ -771,74 +771,60 @@ function InterviewManager() {
 
     this.keywordField = (keys, selectedKeys) => {
         const keywords_options = {
-            el: document.querySelector('.tokenfield_keywords'),
-            multiple: true,
-            minChars: 1,
-            itemName: 'keywords',
-            setItems: selectedKeys
+            minLength: 1,
+            delimiter: [';', 'Tab', 'Enter', 'Numpad Enter'],
+            beautify: true,
         }
 
         if ($('.tokenfield_keywords').data('path') !== undefined) {
-            keywords_options.remote = {
-                url: $('.tokenfield_keywords').data('path'),
-                type: 'GET',
-                queryParam: 'term',
-                params: {
-                    tId: $('.tokenfield_keywords').data('tId'),
-                    typeOfList: $('.tokenfield_keywords').data('typeOfList')
-                }
-            };
-            keywords_options.newItems = false;
-            keywords_options.itemLabel = 'label';
-            keywords_options.itemValue = 'value';
-            keywords_options.itemData = 'label';
-            keywords_options.maxSuggest = parseInt($('.tokenfield_keywords').data('maxSuggest'), 10);
-            keywords_options.setItems = selectedKeys.map((item) => {
-              return { id: item.name, value: item.name, label: item.name }
-            });
-        } else {
-            keywords_options.newItems = true;
-            keywords_options.newItemName = 'keywords';
-            keywords_options.setItems = selectedKeys;
+            keywords_options.autocomplete = {
+                source: function( request, response ) {
+                    $.ajax({
+                        url: $('.tokenfield_keywords').data('path'),
+                        dataType: "json",
+                        data: {
+                            term: request.term,
+                            tId: $('.tokenfield_keywords').data('tId'),
+                            typeOfList: $('.tokenfield_keywords').data('typeOfList')
+                        },
+                        success: function( data ) {
+                          response( data );
+                        }
+                    });
+                },
+            }
         }
 
-        new Tokenfield(keywords_options);
+        $('.tokenfield_keywords').tokenfield(keywords_options);
     }
 
     this.searchField = (keys, selectedKeys) => {
         const subjects_options = {
-          el: document.querySelector('.tokenfield_subjects'),
-          multiple: true,
-          minChars: 1,
-          itemName: 'subjects',
-        };
-
-        if ($('.tokenfield_subjects').data('path') !== undefined) {
-          subjects_options.remote = {
-              url: $('.tokenfield_subjects').data('path'),
-              type: 'GET',
-              queryParam: 'term',
-              params: {
-                  tId: $('.tokenfield_subjects').data('tId'),
-                  typeOfList: $('.tokenfield_subjects').data('typeOfList')
-              }
-          };
-          subjects_options.newItems = false;
-          subjects_options.itemLabel = 'label';
-          subjects_options.itemValue = 'value';
-          subjects_options.itemData = 'label';
-          subjects_options.maxSuggest = parseInt($('.tokenfield_keywords').data('maxSuggest'), 10);
-          subjects_options.setItems = selectedKeys.map((item) => {
-              return { id: item.name, value: item.name, label: item.name }
-            });
-
-        } else {
-            subjects_options.newItems = true;
-            subjects_options.newItemName = 'subjects';
-            subjects_options.setItems = selectedKeys;
+            minLength: 1,
+            delimiter: [';', 'Tab', 'Enter', 'Numpad Enter'],
+            beautify: true,
         }
 
-        new Tokenfield(subjects_options);
+        if ($('.tokenfield_subjects').data('path') !== undefined) {
+            subjects_options.autocomplete = {
+                source: function( request, response ) {
+                    $.ajax({
+                        url: $('.tokenfield_subjects').data('path'),
+                        dataType: "json",
+                        data: {
+                            term: request.term,
+                            tId: $('.tokenfield_subjects').data('tId'),
+                            typeOfList: $('.tokenfield_subjects').data('typeOfList')
+                        },
+                        success: function( data ) {
+                          response( data );
+                        }
+                    });
+                },
+            }
+        }
+
+        $('.tokenfield_subjects').tokenfield(subjects_options);
     }
 
     const bulkAssignUser = () => {

--- a/app/assets/stylesheets/datatables.scss
+++ b/app/assets/stylesheets/datatables.scss
@@ -10,7 +10,7 @@
 //@import 'datatables/extensions/ColReorder/colReorder.bootstrap4';
 //@import 'datatables/extensions/FixedColumns/fixedColumns.bootstrap4';
 //@import 'datatables/extensions/FixedHeader/fixedHeader.bootstrap4';
-//@import 'datatables/extensions/KeyTable/keyTable.bootstrap4';
+@import 'datatables/extensions/KeyTable/keyTable.bootstrap4';
 //@import 'datatables/extensions/Responsive/responsive.bootstrap4';
 //@import 'datatables/extensions/RowGroup/rowGroup.bootstrap4';
 //@import 'datatables/extensions/RowReorder/rowReorder.bootstrap4';

--- a/app/assets/stylesheets/organization.scss
+++ b/app/assets/stylesheets/organization.scss
@@ -199,12 +199,11 @@
 .ohm_summary {
   min-height: 190px !important;
 }
+
 .tokenfield.form-control {
   height: auto;
 }
-.organization-section textarea.form-control {
-  word-break: break-all;
-}
+
 .custom_form .form-control:disabled, 
 .custom_form .form-control[readonly] {
     background-color: #ffffff;

--- a/app/controllers/interviews/managers_controller.rb
+++ b/app/controllers/interviews/managers_controller.rb
@@ -403,12 +403,22 @@ module Interviews
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def interview_params
-      params[:interviews_interview][:keywords] = params[:interviews_interview][:keywords].split('; ') if params[:interviews_interview][:keywords].present?
-      params[:interviews_interview][:subjects] = params[:interviews_interview][:subjects].split('; ') if params[:interviews_interview][:subjects].present?      params.require(:interviews_interview).permit(:title, :accession_number, :interview_date, :date_non_preferred_format, :collection_id, :collection_name, :collection_link, :series_id, :series, :series_link,
-                                                   :summary, :thesaurus_keywords, :thesaurus_subjects, :thesaurus_titles, :transcript_sync_data, :transcript_sync_data_translation, :media_format, :media_host, :media_url,
-                                                   :media_duration, :media_filename, :media_type, :right_statement, :usage_statement, :acknowledgment, :language_info, :include_language, :language_for_translation, :miscellaneous_cms_record_id,
-                                                   :miscellaneous_ohms_xml_filename, :miscellaneous_use_restrictions, :miscellaneous_sync_url, :miscellaneous_user_notes, :interview_status, :status, :avalon_target_domain, :metadata_status,
-                                                   :embed_code, :media_host_account_id, :media_host_player_id, :media_host_item_id, interviewee: [], interviewer: [], keywords: [], subjects: [], format_info: [])
+      if params[:interviews_interview][:keywords].present?
+        params[:interviews_interview][:keywords] = params[:interviews_interview][:keywords].split('; ')
+      end
+
+      if params[:interviews_interview][:subjects].present?
+        params[:interviews_interview][:subjects] = params[:interviews_interview][:subjects].split('; ')
+      end
+
+      params.require(:interviews_interview)
+            .permit(:title, :accession_number, :interview_date, :date_non_preferred_format, :collection_id, :collection_name, :collection_link, :series_id, :series,
+                    :series_link, :summary, :thesaurus_keywords, :thesaurus_subjects, :thesaurus_titles, :transcript_sync_data, :transcript_sync_data_translation,
+                    :media_format, :media_host, :media_url, :media_duration, :media_filename, :media_type, :right_statement, :usage_statement, :acknowledgment,
+                    :language_info, :include_language, :language_for_translation, :miscellaneous_cms_record_id, :miscellaneous_ohms_xml_filename,
+                    :miscellaneous_use_restrictions, :miscellaneous_sync_url, :miscellaneous_user_notes, :interview_status, :status, :avalon_target_domain,
+                    :metadata_status, :embed_code, :media_host_account_id, :media_host_player_id, :media_host_item_id,
+                    interviewee: [], interviewer: [], keywords: [], subjects: [], format_info: [])
     end
 
     def ohms_configuration_params

--- a/app/controllers/interviews/managers_controller.rb
+++ b/app/controllers/interviews/managers_controller.rb
@@ -403,9 +403,8 @@ module Interviews
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def interview_params
-      params[:interviews_interview][:keywords] = params[:keywords] if params[:keywords].present?
-      params[:interviews_interview][:subjects] = params[:subjects] if params[:subjects].present?
-      params.require(:interviews_interview).permit(:title, :accession_number, :interview_date, :date_non_preferred_format, :collection_id, :collection_name, :collection_link, :series_id, :series, :series_link,
+      params[:interviews_interview][:keywords] = params[:interviews_interview][:keywords].split('; ') if params[:interviews_interview][:keywords].present?
+      params[:interviews_interview][:subjects] = params[:interviews_interview][:subjects].split('; ') if params[:interviews_interview][:subjects].present?      params.require(:interviews_interview).permit(:title, :accession_number, :interview_date, :date_non_preferred_format, :collection_id, :collection_name, :collection_link, :series_id, :series, :series_link,
                                                    :summary, :thesaurus_keywords, :thesaurus_subjects, :thesaurus_titles, :transcript_sync_data, :transcript_sync_data_translation, :media_format, :media_host, :media_url,
                                                    :media_duration, :media_filename, :media_type, :right_statement, :usage_statement, :acknowledgment, :language_info, :include_language, :language_for_translation, :miscellaneous_cms_record_id,
                                                    :miscellaneous_ohms_xml_filename, :miscellaneous_use_restrictions, :miscellaneous_sync_url, :miscellaneous_user_notes, :interview_status, :status, :avalon_target_domain, :metadata_status,

--- a/app/controllers/thesaurus/manager_controller.rb
+++ b/app/controllers/thesaurus/manager_controller.rb
@@ -217,7 +217,7 @@ module Thesaurus
 
                     if term.present?
                       terms_all = term.split(' ')
-                      terms_all = terms_all.map { |item| "*#{item.gsub(/[^0-9a-zA-Z ]/i, '')}*" }
+                      terms_all = terms_all.map { |item| "#{item.gsub(/[^0-9a-zA-Z ]/i, '')}*" }
                     end
 
                     thesaurus = ::Thesaurus::ThesaurusTerms.fetch_resources(

--- a/app/models/thesaurus/thesaurus_terms.rb
+++ b/app/models/thesaurus/thesaurus_terms.rb
@@ -35,7 +35,7 @@ module Thesaurus
         fq += ' AND ( '
         query.each_with_index do |term, i|
           fq += ' OR ' if i != 0
-          fq += " term_texts:#{term} " if term.present?
+          fq += " term_scis:#{term} " if term.present?
         end
         fq += ' ) '
       end

--- a/lib/tasks/solr/solr_index_default.rake
+++ b/lib/tasks/solr/solr_index_default.rake
@@ -4,7 +4,7 @@ namespace :aviary do
   namespace :solr_index do
     desc 'Index all objects of Collection for Solr; in descending order'
     task default: :environment do
-      %w'Organization Collection CollectionResource CollectionResourceFile'.each do |klass|
+      %w'Organization Collection CollectionResource CollectionResourceFile FileIndex FileTranscript Interviews::Interview'.each do |klass|
         klass = klass.titleize.delete(' ').constantize
         failed = []
         puts "IDs of #{klass} which are successfully indexed"

--- a/solr/configsets/sunspot/conf/schema.xml
+++ b/solr/configsets/sunspot/conf/schema.xml
@@ -68,7 +68,7 @@
     </fieldType>
 
     <!-- *** This fieldType is used by Sunspot! *** -->
-    <fieldType name="tdouble" class="solr.TrieDoubleField" omitNorms="true"/>
+    <fieldType name="tdouble" class="solr.DoublePointField" omitNorms="true"/>
     <!-- *** This fieldType is used by Sunspot! *** -->
     <fieldType name="rand" class="solr.RandomSortField" omitNorms="true"/>
     <!-- *** This fieldType is used by Sunspot! *** -->
@@ -76,7 +76,6 @@
       <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.StopFilterFactory" words="stopwords.txt" ignoreCase="true"/>
-        <filter class="solr.StandardFilterFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.PorterStemFilterFactory"/>
       </analyzer>
@@ -85,13 +84,13 @@
     <!-- *** This fieldType is used by Sunspot! *** -->
     <fieldType name="boolean" class="solr.BoolField" omitNorms="true"/>
     <!-- *** This fieldType is used by Sunspot! *** -->
-    <fieldType name="tint" class="solr.TrieIntField" omitNorms="true"/>
+    <fieldType name="tint" class="solr.IntPointField" omitNorms="true"/>
     <!-- *** This fieldType is used by Sunspot! *** -->
-    <fieldType name="tlong" class="solr.TrieLongField" omitNorms="true"/>
+    <fieldType name="tlong" class="solr.LongPointField" omitNorms="true"/>
     <!-- *** This fieldType is used by Sunspot! *** -->
-    <fieldType name="tfloat" class="solr.TrieFloatField" omitNorms="true"/>
+    <fieldType name="tfloat" class="solr.FloatPointField" omitNorms="true"/>
     <!-- *** This fieldType is used by Sunspot! *** -->
-    <fieldType name="tdate" class="solr.TrieDateField"
+    <fieldType name="tdate" class="solr.DatePointField"
                omitNorms="true"/>
 
     <fieldType name="daterange" class="solr.DateRangeField" omitNorms="true" />
@@ -105,7 +104,6 @@
     <fieldType name="textSpell" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
       <analyzer>
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <filter class="solr.StandardFilterFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
       </analyzer>
     </fieldType>
@@ -127,7 +125,7 @@
       </analyzer>
     </fieldType>
     <!-- A specialized field for geospatial search. If indexed, this fieldType must not be multivalued. -->
-    <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_coordinate"/>
+    <fieldType name="location" class="solr.LatLonPointSpatialField" docValues="true"/>
     <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
@@ -185,117 +183,117 @@
        when adding a document.
    -->
     <!-- *** This field is used by Sunspot! *** -->
-    <field name="id" stored="true" type="string" multiValued="false" indexed="true"/>
+    <field name="id" stored="true" type="string" multiValued="false" indexed="true"  docValues="true"/>
     <!-- *** This field is used by Sunspot! *** -->
-    <field name="type" stored="false" type="string" multiValued="true" indexed="true"/>
+    <field name="type" stored="false" type="string" multiValued="true" indexed="true"  docValues="true"/>
     <!-- *** This field is used by Sunspot! *** -->
-    <field name="class_name" stored="false" type="string" multiValued="false" indexed="true"/>
+    <field name="class_name" stored="false" type="string" multiValued="false" indexed="true"  docValues="true"/>
     <!-- *** This field is used by Sunspot! *** -->
-    <field name="text" stored="false" type="string" multiValued="true" indexed="true"/>
+    <field name="text" stored="false" type="string" multiValued="true" indexed="true"  docValues="true"/>
     <!-- *** This field is used by Sunspot! *** -->
-    <field name="lat" stored="true" type="tdouble" multiValued="false" indexed="true"/>
+    <field name="lat" stored="true" type="tdouble" multiValued="false" indexed="true"  docValues="true"/>
     <!-- *** This field is used by Sunspot! *** -->
-    <field name="lng" stored="true" type="tdouble" multiValued="false" indexed="true"/>
+    <field name="lng" stored="true" type="tdouble" multiValued="false" indexed="true"  docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="random_*" stored="false" type="rand" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="_local*" stored="false" type="tdouble" multiValued="false" indexed="true"/>
+    <dynamicField name="_local*" stored="false" type="tdouble" multiValued="false" indexed="true"  docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_text" stored="false" type="text_general_rev" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_texts" stored="true" type="text_general_rev" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_b" stored="false" type="boolean" multiValued="false" indexed="true"/>
+    <dynamicField name="*_b" stored="false" type="boolean" multiValued="false" indexed="true"  docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_bm" stored="false" type="boolean" multiValued="true" indexed="true"/>
+    <dynamicField name="*_bm" stored="false" type="boolean" multiValued="true" indexed="true"  docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_bs" stored="true" type="boolean" multiValued="false" indexed="true"/>
+    <dynamicField name="*_bs" stored="true" type="boolean" multiValued="false" indexed="true"  docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_bms" stored="true" type="boolean" multiValued="true" indexed="true"/>
+    <dynamicField name="*_bms" stored="true" type="boolean" multiValued="true" indexed="true"  docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_d" stored="false" type="tdate" multiValued="false" indexed="true"/>
+    <dynamicField name="*_d" stored="false" type="tdate" multiValued="false" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_dm" stored="false" type="tdate" multiValued="true" indexed="true"/>
+    <dynamicField name="*_dm" stored="false" type="tdate" multiValued="true" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_ds" stored="true" type="tdate" multiValued="false" indexed="true"/>
+    <dynamicField name="*_ds" stored="true" type="tdate" multiValued="false" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_dms" stored="true" type="tdate" multiValued="true" indexed="true"/>
+    <dynamicField name="*_dms" stored="true" type="tdate" multiValued="true" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_e" stored="false" type="tdouble" multiValued="false" indexed="true"/>
+    <dynamicField name="*_e" stored="false" type="tdouble" multiValued="false" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_em" stored="false" type="tdouble" multiValued="true" indexed="true"/>
+    <dynamicField name="*_em" stored="false" type="tdouble" multiValued="true" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_es" stored="true" type="tdouble" multiValued="false" indexed="true"/>
+    <dynamicField name="*_es" stored="true" type="tdouble" multiValued="false" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_ems" stored="true" type="tdouble" multiValued="true" indexed="true"/>
+    <dynamicField name="*_ems" stored="true" type="tdouble" multiValued="true" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_f" stored="false" type="tfloat" multiValued="false" indexed="true"/>
+    <dynamicField name="*_f" stored="false" type="tfloat" multiValued="false" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_fm" stored="false" type="tfloat" multiValued="true" indexed="true"/>
+    <dynamicField name="*_fm" stored="false" type="tfloat" multiValued="true" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_fs" stored="true" type="tfloat" multiValued="false" indexed="true"/>
+    <dynamicField name="*_fs" stored="true" type="tfloat" multiValued="false" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_fms" stored="true" type="tfloat" multiValued="true" indexed="true"/>
+    <dynamicField name="*_fms" stored="true" type="tfloat" multiValued="true" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_i" stored="false" type="tint" multiValued="false" indexed="true"/>
+    <dynamicField name="*_i" stored="false" type="tint" multiValued="false" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_im" stored="false" type="tint" multiValued="true" indexed="true"/>
+    <dynamicField name="*_im" stored="false" type="tint" multiValued="true" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_is" stored="true" type="tint" multiValued="false" indexed="true"/>
+    <dynamicField name="*_is" stored="true" type="tint" multiValued="false" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_ims" stored="true" type="tint" multiValued="true" indexed="true"/>
+    <dynamicField name="*_ims" stored="true" type="tint" multiValued="true" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_l" stored="false" type="tlong" multiValued="false" indexed="true"/>
+    <dynamicField name="*_l" stored="false" type="tlong" multiValued="false" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_lm" stored="false" type="tlong" multiValued="true" indexed="true"/>
+    <dynamicField name="*_lm" stored="false" type="tlong" multiValued="true" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_ls" stored="true" type="tlong" multiValued="false" indexed="true"/>
+    <dynamicField name="*_ls" stored="true" type="tlong" multiValued="false" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_lms" stored="true" type="tlong" multiValued="true" indexed="true"/>
+    <dynamicField name="*_lms" stored="true" type="tlong" multiValued="true" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_s" stored="false" type="string" multiValued="false" indexed="true"/>
+    <dynamicField name="*_s" stored="false" type="string" multiValued="false" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_sm" stored="false" type="string" multiValued="true" indexed="true"/>
+    <dynamicField name="*_sm" stored="false" type="string" multiValued="true" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_ss" stored="true" type="string" multiValued="false" indexed="true"/>
+    <dynamicField name="*_ss" stored="true" type="string" multiValued="false" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_sms" stored="true" type="string" multiValued="true" indexed="true"/>
+    <dynamicField name="*_sms" stored="true" type="string" multiValued="true" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_it" stored="false" type="tint" multiValued="false" indexed="true"/>
+    <dynamicField name="*_it" stored="false" type="tint" multiValued="false" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_itm" stored="false" type="tint" multiValued="true" indexed="true"/>
+    <dynamicField name="*_itm" stored="false" type="tint" multiValued="true" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_its" stored="true" type="tint" multiValued="false" indexed="true"/>
+    <dynamicField name="*_its" stored="true" type="tint" multiValued="false" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_itms" stored="true" type="tint" multiValued="true" indexed="true"/>
+    <dynamicField name="*_itms" stored="true" type="tint" multiValued="true" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_ft" stored="false" type="tfloat" multiValued="false" indexed="true"/>
+    <dynamicField name="*_ft" stored="false" type="tfloat" multiValued="false" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_ftm" stored="false" type="tfloat" multiValued="true" indexed="true"/>
+    <dynamicField name="*_ftm" stored="false" type="tfloat" multiValued="true" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_fts" stored="true" type="tfloat" multiValued="false" indexed="true"/>
+    <dynamicField name="*_fts" stored="true" type="tfloat" multiValued="false" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_ftms" stored="true" type="tfloat" multiValued="true" indexed="true"/>
+    <dynamicField name="*_ftms" stored="true" type="tfloat" multiValued="true" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_dt" stored="false" type="tdate" multiValued="false" indexed="true"/>
+    <dynamicField name="*_dt" stored="false" type="tdate" multiValued="false" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_dtm" stored="false" type="tdate" multiValued="true" indexed="true"/>
+    <dynamicField name="*_dtm" stored="false" type="tdate" multiValued="true" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_dts" stored="true" type="tdate" multiValued="false" indexed="true"/>
+    <dynamicField name="*_dts" stored="true" type="tdate" multiValued="false" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_dtms" stored="true" type="tdate" multiValued="true" indexed="true"/>
+    <dynamicField name="*_dtms" stored="true" type="tdate" multiValued="true" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_textv" stored="false" termVectors="true" type="text_general_rev" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_textsv" stored="true" termVectors="true" type="text_general_rev" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_et" stored="false" termVectors="true" type="tdouble" multiValued="false" indexed="true"/>
+    <dynamicField name="*_et" stored="false" termVectors="true" type="tdouble" multiValued="false" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_etm" stored="false" termVectors="true" type="tdouble" multiValued="true" indexed="true"/>
+    <dynamicField name="*_etm" stored="false" termVectors="true" type="tdouble" multiValued="true" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_ets" stored="true" termVectors="true" type="tdouble" multiValued="false" indexed="true"/>
+    <dynamicField name="*_ets" stored="true" termVectors="true" type="tdouble" multiValued="false" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_etms" stored="true" termVectors="true" type="tdouble" multiValued="true" indexed="true"/>
+    <dynamicField name="*_etms" stored="true" termVectors="true" type="tdouble" multiValued="true" indexed="true" docValues="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_dr" stored="false" type="daterange" multiValued="false" indexed="true" />
     <!-- *** This dynamicField is used by Sunspot! *** -->
@@ -306,7 +304,7 @@
     <dynamicField name="*_drms" stored="true" type="daterange" multiValued="true" indexed="true" />
 
     <!-- Type used to index the lat and lon components for the "location" FieldType -->
-    <dynamicField name="*_coordinate"  type="tdouble" indexed="true"  stored="false" multiValued="false"/>
+    <dynamicField name="*_coordinate"  type="tdouble" indexed="true"  stored="false" multiValued="false" docValues="true"/>
     <dynamicField name="*_p" type="location" indexed="true" stored="true" multiValued="false"/>
 
     <dynamicField name="*_ll" stored="false" type="location" multiValued="false" indexed="true"/>

--- a/solr/configsets/sunspot/conf/solrconfig.xml
+++ b/solr/configsets/sunspot/conf/solrconfig.xml
@@ -22,10 +22,8 @@
 -->
 <config>
 
-  <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lib" />
-  <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lucene-libs" />
-  <lib dir="${solr.install.dir:../../../..}/contrib/extraction/lib" regex=".*\.jar" />
-  <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-cell-\d.*\.jar" />
+  <lib dir="${solr.install.dir:../../../..}/modules/analysis-extras/lib" />
+  <lib dir="${solr.install.dir:../../../..}/modules/extraction/lib" regex=".*\.jar" />
 
   <!-- In all configuration below, a prefix of "solr." for class names
        is an alias that causes solr to search appropriate packages,
@@ -41,7 +39,7 @@
        that you fully re-index after changing this setting as it can
        affect both how text is indexed and queried.
   -->
-  <luceneMatchVersion>5.0.0</luceneMatchVersion>
+  <luceneMatchVersion>7.1.0</luceneMatchVersion>
 
   <!-- Data Directory
 
@@ -430,9 +428,14 @@
       <str name="spellcheck.collate">true</str>
       <str name="defType">edismax</str>
       <str name="q.alt">*:*</str>
+      <!-- <str name="q.op">AND</str> -->
+      <str name="uf">* _query_</str>
+      <bool name="useDocValuesAsStored">false</bool>
       <str name="rows">10</str>
       <int name="qs">2</int>
       <int name="ps">4</int>
+      <!-- <str name="df">keywords</str> -->
+
       <!--<str name="qf">-->
       <!--id-->
       <!--title_ss-->


### PR DESCRIPTION
- [x] Aviary-3743 - Made all the `datatables` keyboard accessible like spreadsheets
- [x] Aviary-3750 - Update Solr to 9.3.0
- [x] Aviary-3786 - Prefer start of string while searching for `thesaurus_terms`
- [x] Aviary-3767 - Allow users to add new values into `subjects` and `keywords` fields on `OHMS` `Metadata Editor` and `Indexes` when the thesaurus is assigned to fields
- [x] Aviary-3768-3769 - Removed css `break-all` from ohms text fields