### PR TITLE
AVIARY-4130 Fix vimeo unlisted videos issue

### DIFF
--- a/app/helpers/interview_index_helper.rb
+++ b/app/helpers/interview_index_helper.rb
@@ -74,7 +74,7 @@ module InterviewIndexHelper
     elsif interview.media_host == 'Vimeo'
       regex = %r{https?:\/\/(?:\w+\.)*vimeo\.com(?:[\/\w]*\/?)?\/(?<id>[0-9]+)[^\s]*}
       match = regex.match(interview.embed_code)
-      data['src'] = "https://player.vimeo.com/video/#{match[1]}"
+      data['src'] = match[0]
     end
     data
   end


### PR DESCRIPTION
Changes: 

- [x] Use Full video URL since it contains h attribute for hash decoding for unlisted Vimeo videos.